### PR TITLE
Add I18N feature

### DIFF
--- a/lib/Mojolicious/Plugin/BootstrapPagination.pm
+++ b/lib/Mojolicious/Plugin/BootstrapPagination.pm
@@ -18,6 +18,10 @@ sub  register{
 
   $app->helper( bootstrap_pagination => sub{
       my ( $self, $actual, $count, $opts ) = @_;
+
+      my $localize = ( $opts->{localize} || $args->{localize} ) ?
+          ( $opts->{localize} || $args->{localize} ) : undef;
+
       $count = ceil($count);
       return "" unless $count > 1;
       $opts = {} unless $opts;
@@ -52,6 +56,11 @@ sub  register{
       my $last_num = -1;
       foreach my $number( @ret ){
         my $show_number = $start > 0 ? $number : ( $number =~ /\d+/ ? $number + 1 : $number );
+
+        if ( $localize ) {
+            $show_number = $localize->($show_number);
+        }
+
         if( $number eq ".." && $last_num < $actual ){
           my $offset = ceil( ( $actual - $round ) / 2 ) + 1 ;
           $html .= "<li><a href=\"" . $self->url_with->query( [$param => $start == 0 ? $offset + 1 : $offset] ) . $query ."\" >&hellip;</a></li>";
@@ -144,6 +153,37 @@ Additional query string to url. Optional.
 Start number for query string. Default: 1. Optional.
 
 =back
+
+=head1 INTERNATIONALIZATION
+
+If you want to use internationalization (I18N), you can pass a coderef via I<localize>.
+
+  plugin 'bootstrap_pagination' => {
+    localize => \&localize,
+  };
+  
+  sub localize {
+    my ($number) = @_;
+  
+    my %trans = (
+      1 => 'one',
+      2 => 'two',
+      6 => 'six',
+      7 => 'seven',
+      8 => 'eight',
+      9 => 'nine',
+     10 => 'ten',
+     11 => 'eleven',
+     12 => 'twelve',
+     13 => 'thirteen',
+     14 => 'fourteen',
+     15 => 'fifteen',
+    );
+  
+    return $trans{$number};
+  }
+
+This will print the words instead of the numbers.
 
 =head1 SEE ALSO
 

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+BEGIN{
+  $ENV{MOJO_NO_IPV6} = $ENV{MOJO_POLL} = 1 ;
+  $ENV{MOJO_APP} = undef; # 
+}
+use Test::More;
+use Test::Mojo;
+
+
+use Mojolicious::Lite;
+plugin 'bootstrap_pagination' => {
+   localize => \&localize,
+};
+get( "/" => sub(){
+    my $self = shift;
+    $self->render( text => $self->bootstrap_pagination( 10, 15 ) . "\n" );
+  } );
+
+my $t = Test::Mojo->new(  );
+$t->get_ok( "/" )
+  ->status_is( 200 )
+  ->content_is(<<EOF);
+<ul class="pagination"><li><a href="/?page=9" >&laquo;</a></li><li><a href="/?page=1">one</a></li><li><a href="/?page=2">two</a></li><li><a href="/?page=4" >&hellip;</a></li><li><a href="/?page=6">six</a></li><li><a href="/?page=7">seven</a></li><li><a href="/?page=8">eight</a></li><li><a href="/?page=9">nine</a></li><li class="active"><span>ten</span></li><li><a href="/?page=11">eleven</a></li><li><a href="/?page=12">twelve</a></li><li><a href="/?page=13">thirteen</a></li><li><a href="/?page=14">fourteen</a></li><li><a href="/?page=15">fifteen</a></li><li><a href="/?page=11" >&raquo;</a></li></ul>
+EOF
+
+done_testing();
+
+sub localize {
+    my ($number) = @_;
+
+    my %trans = (
+      1 => 'one',
+      2 => 'two',
+      6 => 'six',
+      7 => 'seven',
+      8 => 'eight',
+      9 => 'nine',
+     10 => 'ten',
+     11 => 'eleven',
+     12 => 'twelve',
+     13 => 'thirteen',
+     14 => 'fourteen',
+     15 => 'fifteen',
+    );
+
+    return $trans{$number};
+}
+


### PR DESCRIPTION
When building software that should run in many countries, the pagination should be translatable. With this patch, one can pass a coderef to a translation subroutine...