### PR TITLE
Allow setting css class on the page item

### DIFF
--- a/META.json
+++ b/META.json
@@ -65,7 +65,7 @@
          "web" : "https://github.com/dokechin/Mojolicious-Plugin-BootstrapPagination"
       }
    },
-   "version" : "0.13",
+   "version" : "0.14",
    "x_contributors" : [
       "Andrey Kuzmin <chips@reg.ru>",
       "Alexander Groshev <sattellite@yandex.ru>",

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options is a optional ref hash.
         query => "&id=$id",
         start => 1,
         class => 'pagination-lg',
+        item_class => 'page-item',
         param => 'page' } );
 
 - round

--- a/lib/Mojolicious/Plugin/BootstrapPagination.pm
+++ b/lib/Mojolicious/Plugin/BootstrapPagination.pm
@@ -6,7 +6,7 @@ use Mojo::ByteStream 'b';
 use strict;
 use warnings;
 
-our $VERSION = "0.13";
+our $VERSION = "0.14";
 
 # Homer: Well basically, I just copied the plant we have now.
 #        Then, I added some fins to lower wind resistance.  
@@ -28,6 +28,8 @@ sub  register{
       my $round = $opts->{round} || $args->{round} || 4;
       my $param = $opts->{param} || $args->{param} || "page";
       my $class = $opts->{class} || $args->{class} || "";
+      my $item_class = $opts->{item_class} || $args->{item_class} || "";
+
       if ($class ne ""){
           $class = " " . $class;
       }
@@ -49,9 +51,9 @@ sub  register{
       }
       my $html = "<ul class=\"pagination$class\">";
       if( $actual == $start ){
-        $html .= "<li class=\"disabled\"><a href=\"#\" >&laquo;</a></li>";
+        $html .= "<li class=\"disabled $item_class\"><a href=\"#\" >&laquo;</a></li>";
       } else {
-        $html .= "<li><a href=\"" . $self->url_with->query( [$param => $actual - 1] ) . $query . "\" >&laquo;</a></li>";
+        $html .= "<li class=\"$item_class\"""><a href=\"" . $self->url_with->query( [$param => $actual - 1] ) . $query . "\" >&laquo;</a></li>";
       }
       my $last_num = -1;
       foreach my $number( @ret ){
@@ -63,24 +65,24 @@ sub  register{
 
         if( $number eq ".." && $last_num < $actual ){
           my $offset = ceil( ( $actual - $round ) / 2 ) + 1 ;
-          $html .= "<li><a href=\"" . $self->url_with->query( [$param => $start == 0 ? $offset + 1 : $offset] ) . $query ."\" >&hellip;</a></li>";
+          $html .= "<li class=\"$item_class\"><a href=\"" . $self->url_with->query( [$param => $start == 0 ? $offset + 1 : $offset] ) . $query ."\" >&hellip;</a></li>";
         }
         elsif( $number eq ".." && $last_num > $actual ) {
           my $back = $count - $outer + 1;
           my $forw = $round + $actual;
           my $offset = ceil( ( ( $back - $forw ) / 2 ) + $forw );
-          $html .= "<li><a href=\"" . $self->url_with->query( [$param => $start == 0 ? $offset + 1 : $offset] ) . $query ."\" >&hellip;</a></li>";
+          $html .= "<li class=\"$item_class\"><a href=\"" . $self->url_with->query( [$param => $start == 0 ? $offset + 1 : $offset] ) . $query ."\" >&hellip;</a></li>";
         } elsif( $number == $actual ) {
-          $html .= "<li class=\"active\"><span>$show_number</span></li>";
+          $html .= "<li class=\"active $item_class\"><span>$show_number</span></li>";
         } else {
-          $html .= "<li><a href=\"" . $self->url_with->query( [$param => $number] ) . $query ."\">$show_number</a></li>";
+          $html .= "<li class=\"$item_class\"><a href=\"" . $self->url_with->query( [$param => $number] ) . $query ."\">$show_number</a></li>";
         }
          $last_num = $number;
       }
       if( $actual == $count ){
-        $html .= "<li class=\"disabled\"><a href=\"" . $self->url_with->query( [$param => $actual + 1] ) . $query . "\" >&raquo;</a></li>";
+        $html .= "<li class=\"disabled $item_class\"><a href=\"" . $self->url_with->query( [$param => $actual + 1] ) . $query . "\" >&raquo;</a></li>";
       } else {
-        $html .= "<li><a href=\"" . $self->url_with->query( [$param => $actual + 1] ) . $query . "\" >&raquo;</a></li>";
+        $html .= "<li class=\"$item_class\"><a href=\"" . $self->url_with->query( [$param => $actual + 1] ) . $query . "\" >&raquo;</a></li>";
       }
       $html .= "</ul>";
       return b( $html );
@@ -128,6 +130,7 @@ Options is a optional ref hash.
       query => "&id=$id",
       start => 1,
       class => 'pagination-lg',
+      item_class => 'page-item',
       param => 'page' } );
 
 =over 1

--- a/lib/Mojolicious/Plugin/BootstrapPagination.pm
+++ b/lib/Mojolicious/Plugin/BootstrapPagination.pm
@@ -28,7 +28,7 @@ sub  register{
       my $round = $opts->{round} || $args->{round} || 4;
       my $param = $opts->{param} || $args->{param} || "page";
       my $class = $opts->{class} || $args->{class} || "";
-      my $item_class = $opts->{item_class} || $args->{item_class} || "";
+      my $item_class = $opts->{item_class} || $args->{item_class} || "page-item";
 
       if ($class ne ""){
           $class = " " . $class;
@@ -53,7 +53,7 @@ sub  register{
       if( $actual == $start ){
         $html .= "<li class=\"disabled $item_class\"><a href=\"#\" >&laquo;</a></li>";
       } else {
-        $html .= "<li class=\"$item_class\"""><a href=\"" . $self->url_with->query( [$param => $actual - 1] ) . $query . "\" >&laquo;</a></li>";
+        $html .= "<li class=\"$item_class\"><a href=\"" . $self->url_with->query( [$param => $actual - 1] ) . $query . "\" >&laquo;</a></li>";
       }
       my $last_num = -1;
       foreach my $number( @ret ){

--- a/t/01_bootstrap_pagination.t
+++ b/t/01_bootstrap_pagination.t
@@ -27,7 +27,7 @@ get( "/none" => sub(){
 
 get( "/class" => sub(){
     my $self = shift;
-    $self->render( text => $self->bootstrap_pagination( 1, 2, {class=>"test"}) . "\n" );
+    $self->render( text => $self->bootstrap_pagination( 1, 2, {class=>"test", item_class=>"page-item-test"}) . "\n" );
   } );
 
 get( "/param" => sub(){
@@ -64,7 +64,7 @@ my $t = Test::Mojo->new(  );
 $t->get_ok( "/" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/?page=9" >&laquo;</a></li><li><a href="/?page=1">1</a></li><li><a href="/?page=2">2</a></li><li><a href="/?page=4" >&hellip;</a></li><li><a href="/?page=6">6</a></li><li><a href="/?page=7">7</a></li><li><a href="/?page=8">8</a></li><li><a href="/?page=9">9</a></li><li class="active"><span>10</span></li><li><a href="/?page=11">11</a></li><li><a href="/?page=12">12</a></li><li><a href="/?page=13">13</a></li><li><a href="/?page=14">14</a></li><li><a href="/?page=15">15</a></li><li><a href="/?page=11" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/?page=9" >&laquo;</a></li><li class="page-item"><a href="/?page=1">1</a></li><li class="page-item"><a href="/?page=2">2</a></li><li class="page-item"><a href="/?page=4" >&hellip;</a></li><li class="page-item"><a href="/?page=6">6</a></li><li class="page-item"><a href="/?page=7">7</a></li><li class="page-item"><a href="/?page=8">8</a></li><li class="page-item"><a href="/?page=9">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/?page=11">11</a></li><li class="page-item"><a href="/?page=12">12</a></li><li class="page-item"><a href="/?page=13">13</a></li><li class="page-item"><a href="/?page=14">14</a></li><li class="page-item"><a href="/?page=15">15</a></li><li class="page-item"><a href="/?page=11" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/none" )
@@ -76,41 +76,41 @@ EOF
 $t->get_ok( "/class" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test"><li class="disabled"><a href="#" >&laquo;</a></li><li class="active"><span>1</span></li><li><a href="/class?page=2">2</a></li><li><a href="/class?page=2" >&raquo;</a></li></ul>
+<ul class="pagination test"><li class="disabled page-item-test"><a href="#" >&laquo;</a></li><li class="active page-item-test"><span>1</span></li><li class="page-item-test"><a href="/class?page=2">2</a></li><li class="page-item-test"><a href="/class?page=2" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/param" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li class="disabled"><a href="#" >&laquo;</a></li><li class="active"><span>1</span></li><li><a href="/param?p=2">2</a></li><li><a href="/param?p=2" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="disabled page-item"><a href="#" >&laquo;</a></li><li class="active page-item"><span>1</span></li><li class="page-item"><a href="/param?p=2">2</a></li><li class="page-item"><a href="/param?p=2" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/round" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/round?page=9" >&laquo;</a></li><li><a href="/round?page=1">1</a></li><li><a href="/round?page=2">2</a></li><li><a href="/round?page=6" >&hellip;</a></li><li><a href="/round?page=9">9</a></li><li class="active"><span>10</span></li><li><a href="/round?page=11">11</a></li><li><a href="/round?page=13" >&hellip;</a></li><li><a href="/round?page=14">14</a></li><li><a href="/round?page=15">15</a></li><li><a href="/round?page=11" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/round?page=9" >&laquo;</a></li><li class="page-item"><a href="/round?page=1">1</a></li><li class="page-item"><a href="/round?page=2">2</a></li><li class="page-item"><a href="/round?page=6" >&hellip;</a></li><li class="page-item"><a href="/round?page=9">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/round?page=11">11</a></li><li class="page-item"><a href="/round?page=13" >&hellip;</a></li><li class="page-item"><a href="/round?page=14">14</a></li><li class="page-item"><a href="/round?page=15">15</a></li><li class="page-item"><a href="/round?page=11" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/outer" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/outer?page=9" >&laquo;</a></li><li><a href="/outer?page=1">1</a></li><li><a href="/outer?page=6" >&hellip;</a></li><li><a href="/outer?page=9">9</a></li><li class="active"><span>10</span></li><li><a href="/outer?page=11">11</a></li><li><a href="/outer?page=13" >&hellip;</a></li><li><a href="/outer?page=15">15</a></li><li><a href="/outer?page=11" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/outer?page=9" >&laquo;</a></li><li class="page-item"><a href="/outer?page=1">1</a></li><li class="page-item"><a href="/outer?page=6" >&hellip;</a></li><li class="page-item"><a href="/outer?page=9">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/outer?page=11">11</a></li><li class="page-item"><a href="/outer?page=13" >&hellip;</a></li><li class="page-item"><a href="/outer?page=15">15</a></li><li class="page-item"><a href="/outer?page=11" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/query" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/query?page=4&id1=value1" >&laquo;</a></li><li><a href="/query?page=1&id1=value1">1</a></li><li><a href="/query?page=3&id1=value1" >&hellip;</a></li><li><a href="/query?page=4&id1=value1">4</a></li><li class="active"><span>5</span></li><li><a href="/query?page=6&id1=value1">6</a></li><li><a href="/query?page=8&id1=value1" >&hellip;</a></li><li><a href="/query?page=10&id1=value1">10</a></li><li><a href="/query?page=6&id1=value1" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/query?page=4&id1=value1" >&laquo;</a></li><li class="page-item"><a href="/query?page=1&id1=value1">1</a></li><li class="page-item"><a href="/query?page=3&id1=value1" >&hellip;</a></li><li class="page-item"><a href="/query?page=4&id1=value1">4</a></li><li class="active page-item"><span>5</span></li><li class="page-item"><a href="/query?page=6&id1=value1">6</a></li><li class="page-item"><a href="/query?page=8&id1=value1" >&hellip;</a></li><li class="page-item"><a href="/query?page=10&id1=value1">10</a></li><li class="page-item"><a href="/query?page=6&id1=value1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/start" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/start?page=8" >&laquo;</a></li><li><a href="/start?page=2">2</a></li><li><a href="/start?page=5" >&hellip;</a></li><li><a href="/start?page=8">8</a></li><li class="active"><span>9</span></li><li><a href="/start?page=10">10</a></li><li><a href="/start?page=14" >&hellip;</a></li><li><a href="/start?page=18">18</a></li><li><a href="/start?page=10" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/start?page=8" >&laquo;</a></li><li class="page-item"><a href="/start?page=2">2</a></li><li class="page-item"><a href="/start?page=5" >&hellip;</a></li><li class="page-item"><a href="/start?page=8">8</a></li><li class="active page-item"><span>9</span></li><li class="page-item"><a href="/start?page=10">10</a></li><li class="page-item"><a href="/start?page=14" >&hellip;</a></li><li class="page-item"><a href="/start?page=18">18</a></li><li class="page-item"><a href="/start?page=10" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/start2?id=1" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/start2?id=1&page=8" >&laquo;</a></li><li><a href="/start2?id=1&page=2">2</a></li><li><a href="/start2?id=1&page=5" >&hellip;</a></li><li><a href="/start2?id=1&page=8">8</a></li><li class="active"><span>9</span></li><li><a href="/start2?id=1&page=10">10</a></li><li><a href="/start2?id=1&page=14" >&hellip;</a></li><li><a href="/start2?id=1&page=18">18</a></li><li><a href="/start2?id=1&page=10" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/start2?id=1&page=8" >&laquo;</a></li><li class="page-item"><a href="/start2?id=1&page=2">2</a></li><li class="page-item"><a href="/start2?id=1&page=5" >&hellip;</a></li><li class="page-item"><a href="/start2?id=1&page=8">8</a></li><li class="active page-item"><span>9</span></li><li class="page-item"><a href="/start2?id=1&page=10">10</a></li><li class="page-item"><a href="/start2?id=1&page=14" >&hellip;</a></li><li class="page-item"><a href="/start2?id=1&page=18">18</a></li><li class="page-item"><a href="/start2?id=1&page=10" >&raquo;</a></li></ul>
 EOF

--- a/t/02_global_attributes.t
+++ b/t/02_global_attributes.t
@@ -65,7 +65,7 @@ my $t = Test::Mojo->new(  );
 $t->get_ok( "/" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/?page=9&id=1" >&laquo;</a></li><li><a href="/?page=1&id=1">1</a></li><li><a href="/?page=2&id=1">2</a></li><li><a href="/?page=5&id=1" >&hellip;</a></li><li><a href="/?page=8&id=1">8</a></li><li><a href="/?page=9&id=1">9</a></li><li class="active"><span>10</span></li><li><a href="/?page=11&id=1">11</a></li><li><a href="/?page=12&id=1">12</a></li><li><a href="/?page=13&id=1" >&hellip;</a></li><li><a href="/?page=14&id=1">14</a></li><li><a href="/?page=15&id=1">15</a></li><li><a href="/?page=11&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/?page=9&id=1" >&laquo;</a></li><li class="page-item"><a href="/?page=1&id=1">1</a></li><li class="page-item"><a href="/?page=2&id=1">2</a></li><li class="page-item"><a href="/?page=5&id=1" >&hellip;</a></li><li class="page-item"><a href="/?page=8&id=1">8</a></li><li class="page-item"><a href="/?page=9&id=1">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/?page=11&id=1">11</a></li><li class="page-item"><a href="/?page=12&id=1">12</a></li><li class="page-item"><a href="/?page=13&id=1" >&hellip;</a></li><li class="page-item"><a href="/?page=14&id=1">14</a></li><li class="page-item"><a href="/?page=15&id=1">15</a></li><li class="page-item"><a href="/?page=11&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/none" )
@@ -77,41 +77,41 @@ EOF
 $t->get_ok( "/class" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test"><li class="disabled"><a href="#" >&laquo;</a></li><li class="active"><span>1</span></li><li><a href="/class?page=2&id=1">2</a></li><li><a href="/class?page=2&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test"><li class="disabled page-item"><a href="#" >&laquo;</a></li><li class="active page-item"><span>1</span></li><li class="page-item"><a href="/class?page=2&id=1">2</a></li><li class="page-item"><a href="/class?page=2&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/param" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li class="disabled"><a href="#" >&laquo;</a></li><li class="active"><span>1</span></li><li><a href="/param?p=2&id=1">2</a></li><li><a href="/param?p=2&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="disabled page-item"><a href="#" >&laquo;</a></li><li class="active page-item"><span>1</span></li><li class="page-item"><a href="/param?p=2&id=1">2</a></li><li class="page-item"><a href="/param?p=2&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/round" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/round?page=9&id=1" >&laquo;</a></li><li><a href="/round?page=1&id=1">1</a></li><li><a href="/round?page=2&id=1">2</a></li><li><a href="/round?page=6&id=1" >&hellip;</a></li><li><a href="/round?page=9&id=1">9</a></li><li class="active"><span>10</span></li><li><a href="/round?page=11&id=1">11</a></li><li><a href="/round?page=13&id=1" >&hellip;</a></li><li><a href="/round?page=14&id=1">14</a></li><li><a href="/round?page=15&id=1">15</a></li><li><a href="/round?page=11&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/round?page=9&id=1" >&laquo;</a></li><li class="page-item"><a href="/round?page=1&id=1">1</a></li><li class="page-item"><a href="/round?page=2&id=1">2</a></li><li class="page-item"><a href="/round?page=6&id=1" >&hellip;</a></li><li class="page-item"><a href="/round?page=9&id=1">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/round?page=11&id=1">11</a></li><li class="page-item"><a href="/round?page=13&id=1" >&hellip;</a></li><li class="page-item"><a href="/round?page=14&id=1">14</a></li><li class="page-item"><a href="/round?page=15&id=1">15</a></li><li class="page-item"><a href="/round?page=11&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/outer" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/outer?page=9&id=1" >&laquo;</a></li><li><a href="/outer?page=1&id=1">1</a></li><li><a href="/outer?page=6&id=1" >&hellip;</a></li><li><a href="/outer?page=9&id=1">9</a></li><li class="active"><span>10</span></li><li><a href="/outer?page=11&id=1">11</a></li><li><a href="/outer?page=13&id=1" >&hellip;</a></li><li><a href="/outer?page=15&id=1">15</a></li><li><a href="/outer?page=11&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/outer?page=9&id=1" >&laquo;</a></li><li class="page-item"><a href="/outer?page=1&id=1">1</a></li><li class="page-item"><a href="/outer?page=6&id=1" >&hellip;</a></li><li class="page-item"><a href="/outer?page=9&id=1">9</a></li><li class="active page-item"><span>10</span></li><li class="page-item"><a href="/outer?page=11&id=1">11</a></li><li class="page-item"><a href="/outer?page=13&id=1" >&hellip;</a></li><li class="page-item"><a href="/outer?page=15&id=1">15</a></li><li class="page-item"><a href="/outer?page=11&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/query" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/query?page=4&id1=value1" >&laquo;</a></li><li><a href="/query?page=1&id1=value1">1</a></li><li><a href="/query?page=3&id1=value1" >&hellip;</a></li><li><a href="/query?page=4&id1=value1">4</a></li><li class="active"><span>5</span></li><li><a href="/query?page=6&id1=value1">6</a></li><li><a href="/query?page=8&id1=value1" >&hellip;</a></li><li><a href="/query?page=10&id1=value1">10</a></li><li><a href="/query?page=6&id1=value1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/query?page=4&id1=value1" >&laquo;</a></li><li class="page-item"><a href="/query?page=1&id1=value1">1</a></li><li class="page-item"><a href="/query?page=3&id1=value1" >&hellip;</a></li><li class="page-item"><a href="/query?page=4&id1=value1">4</a></li><li class="active page-item"><span>5</span></li><li class="page-item"><a href="/query?page=6&id1=value1">6</a></li><li class="page-item"><a href="/query?page=8&id1=value1" >&hellip;</a></li><li class="page-item"><a href="/query?page=10&id1=value1">10</a></li><li class="page-item"><a href="/query?page=6&id1=value1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/start" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/start?page=8&id=1" >&laquo;</a></li><li><a href="/start?page=2&id=1">2</a></li><li><a href="/start?page=5&id=1" >&hellip;</a></li><li><a href="/start?page=8&id=1">8</a></li><li class="active"><span>9</span></li><li><a href="/start?page=10&id=1">10</a></li><li><a href="/start?page=14&id=1" >&hellip;</a></li><li><a href="/start?page=18&id=1">18</a></li><li><a href="/start?page=10&id=1" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/start?page=8&id=1" >&laquo;</a></li><li class="page-item"><a href="/start?page=2&id=1">2</a></li><li class="page-item"><a href="/start?page=5&id=1" >&hellip;</a></li><li class="page-item"><a href="/start?page=8&id=1">8</a></li><li class="active page-item"><span>9</span></li><li class="page-item"><a href="/start?page=10&id=1">10</a></li><li class="page-item"><a href="/start?page=14&id=1" >&hellip;</a></li><li class="page-item"><a href="/start?page=18&id=1">18</a></li><li class="page-item"><a href="/start?page=10&id=1" >&raquo;</a></li></ul>
 EOF
 
 $t->get_ok( "/start2?id=1" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination test2"><li><a href="/start2?id=1&page=8" >&laquo;</a></li><li><a href="/start2?id=1&page=2">2</a></li><li><a href="/start2?id=1&page=5" >&hellip;</a></li><li><a href="/start2?id=1&page=8">8</a></li><li class="active"><span>9</span></li><li><a href="/start2?id=1&page=10">10</a></li><li><a href="/start2?id=1&page=14" >&hellip;</a></li><li><a href="/start2?id=1&page=18">18</a></li><li><a href="/start2?id=1&page=10" >&raquo;</a></li></ul>
+<ul class="pagination test2"><li class="page-item"><a href="/start2?id=1&page=8" >&laquo;</a></li><li class="page-item"><a href="/start2?id=1&page=2">2</a></li><li class="page-item"><a href="/start2?id=1&page=5" >&hellip;</a></li><li class="page-item"><a href="/start2?id=1&page=8">8</a></li><li class="active page-item"><span>9</span></li><li class="page-item"><a href="/start2?id=1&page=10">10</a></li><li class="page-item"><a href="/start2?id=1&page=14" >&hellip;</a></li><li class="page-item"><a href="/start2?id=1&page=18">18</a></li><li class="page-item"><a href="/start2?id=1&page=10" >&raquo;</a></li></ul>
 EOF

--- a/t/03_i18n.t
+++ b/t/03_i18n.t
@@ -24,7 +24,7 @@ my $t = Test::Mojo->new(  );
 $t->get_ok( "/" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/?page=9" >&laquo;</a></li><li><a href="/?page=1">one</a></li><li><a href="/?page=2">two</a></li><li><a href="/?page=4" >&hellip;</a></li><li><a href="/?page=6">six</a></li><li><a href="/?page=7">seven</a></li><li><a href="/?page=8">eight</a></li><li><a href="/?page=9">nine</a></li><li class="active"><span>ten</span></li><li><a href="/?page=11">eleven</a></li><li><a href="/?page=12">twelve</a></li><li><a href="/?page=13">thirteen</a></li><li><a href="/?page=14">fourteen</a></li><li><a href="/?page=15">fifteen</a></li><li><a href="/?page=11" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/?page=9" >&laquo;</a></li><li class="page-item"><a href="/?page=1">one</a></li><li class="page-item"><a href="/?page=2">two</a></li><li class="page-item"><a href="/?page=4" >&hellip;</a></li><li class="page-item"><a href="/?page=6">six</a></li><li class="page-item"><a href="/?page=7">seven</a></li><li class="page-item"><a href="/?page=8">eight</a></li><li class="page-item"><a href="/?page=9">nine</a></li><li class="active page-item"><span>ten</span></li><li class="page-item"><a href="/?page=11">eleven</a></li><li class="page-item"><a href="/?page=12">twelve</a></li><li class="page-item"><a href="/?page=13">thirteen</a></li><li class="page-item"><a href="/?page=14">fourteen</a></li><li class="page-item"><a href="/?page=15">fifteen</a></li><li class="page-item"><a href="/?page=11" >&raquo;</a></li></ul>
 EOF
 
 done_testing();

--- a/t/04_i18n.t
+++ b/t/04_i18n.t
@@ -29,7 +29,7 @@ my $t = Test::Mojo->new(  );
 $t->get_ok( "/" )
   ->status_is( 200 )
   ->content_is(<<EOF);
-<ul class="pagination"><li><a href="/?page=9" >&laquo;</a></li><li><a href="/?page=1">one</a></li><li><a href="/?page=2">two</a></li><li><a href="/?page=4" >&hellip;</a></li><li><a href="/?page=6">six</a></li><li><a href="/?page=7">seven</a></li><li><a href="/?page=8">eight</a></li><li><a href="/?page=9">nine</a></li><li class="active"><span>ten</span></li><li><a href="/?page=11">eleven</a></li><li><a href="/?page=12">twelve</a></li><li><a href="/?page=13">thirteen</a></li><li><a href="/?page=14">fourteen</a></li><li><a href="/?page=15">fifteen</a></li><li><a href="/?page=11" >&raquo;</a></li></ul>
+<ul class="pagination"><li class="page-item"><a href="/?page=9" >&laquo;</a></li><li class="page-item"><a href="/?page=1">one</a></li><li class="page-item"><a href="/?page=2">two</a></li><li class="page-item"><a href="/?page=4" >&hellip;</a></li><li class="page-item"><a href="/?page=6">six</a></li><li class="page-item"><a href="/?page=7">seven</a></li><li class="page-item"><a href="/?page=8">eight</a></li><li class="page-item"><a href="/?page=9">nine</a></li><li class="active page-item"><span>ten</span></li><li class="page-item"><a href="/?page=11">eleven</a></li><li class="page-item"><a href="/?page=12">twelve</a></li><li class="page-item"><a href="/?page=13">thirteen</a></li><li class="page-item"><a href="/?page=14">fourteen</a></li><li class="page-item"><a href="/?page=15">fifteen</a></li><li class="page-item"><a href="/?page=11" >&raquo;</a></li></ul>
 EOF
 
 done_testing();


### PR DESCRIPTION
I want to style the inner `li` items. As per [Bootstap documentation](https://getbootstrap.com/docs/4.1/components/pagination/) we can introduce a `page-item` class, if needed, to style these elements.

This pull request adds `page-item` css class to all `<li>` elements.